### PR TITLE
Handle new directories added

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ GitHub Action for checking the status of the working tree. If any files are untr
 ## Usage
 
 ```yaml
-- uses: pulumi/git-status-check@v1
+- uses: pulumi/git-status-check-action@v1
   with:
     # One of more globs to list files which are permitted 
     # to have uncommitted changes.

--- a/dist/index.js
+++ b/dist/index.js
@@ -38710,40 +38710,53 @@ function statusCheck(options) {
                                         return [2 /*return*/, "continue"];
                                     }
                                     return [4 /*yield*/, (0, core_1.group)(statusLine, function () { return __awaiter(_this, void 0, void 0, function () {
-                                            var _a, newContent, oldFile, diff;
+                                            var _a, lstat, dirContent, newContent, oldFile, diff;
                                             return __generator(this, function (_b) {
                                                 switch (_b.label) {
                                                     case 0:
                                                         _a = modification;
                                                         switch (_a) {
                                                             case "added": return [3 /*break*/, 1];
-                                                            case "deleted": return [3 /*break*/, 3];
-                                                            case "modified": return [3 /*break*/, 4];
+                                                            case "deleted": return [3 /*break*/, 7];
+                                                            case "modified": return [3 /*break*/, 8];
                                                         }
-                                                        return [3 /*break*/, 5];
-                                                    case 1: return [4 /*yield*/, getNew(path)];
+                                                        return [3 /*break*/, 9];
+                                                    case 1: return [4 /*yield*/, fs_1.promises.lstat((0, path_1.join)(options.dir, path))];
                                                     case 2:
+                                                        lstat = _b.sent();
+                                                        if (!lstat.isDirectory()) return [3 /*break*/, 4];
+                                                        return [4 /*yield*/, fs_1.promises.readdir((0, path_1.join)(options.dir, path))];
+                                                    case 3:
+                                                        dirContent = _b.sent();
+                                                        options.alert("Directory added:\n" + dirContent.join("\n"), {
+                                                            file: path,
+                                                            title: "Unexpected directory added",
+                                                        });
+                                                        return [3 /*break*/, 6];
+                                                    case 4: return [4 /*yield*/, getNew(path)];
+                                                    case 5:
                                                         newContent = _b.sent();
                                                         options.alert("File added:\n" + newContent, {
                                                             file: path,
                                                             title: "Unexpected file added",
                                                         });
-                                                        return [3 /*break*/, 5];
-                                                    case 3:
+                                                        _b.label = 6;
+                                                    case 6: return [3 /*break*/, 9];
+                                                    case 7:
                                                         oldFile = getOld(path);
                                                         options.alert("File deleted:\n" + oldFile, {
                                                             file: path,
                                                             title: "Unexpected file deleted",
                                                         });
-                                                        return [3 /*break*/, 5];
-                                                    case 4:
+                                                        return [3 /*break*/, 9];
+                                                    case 8:
                                                         diff = getDiff(path);
                                                         options.alert("File modified:\n" + trimPatchHeader(diff), {
                                                             file: path,
                                                             title: "Unexpected file modified",
                                                         });
-                                                        return [3 /*break*/, 5];
-                                                    case 5:
+                                                        return [3 /*break*/, 9];
+                                                    case 9:
                                                         unexpectedChangesCount++;
                                                         return [2 /*return*/];
                                                 }

--- a/src/statusCheck.ts
+++ b/src/statusCheck.ts
@@ -80,11 +80,20 @@ export async function statusCheck(
     await group(statusLine, async () => {
       switch (modification) {
         case "added":
-          const newContent = await getNew(path);
-          options.alert("File added:\n" + newContent, {
-            file: path,
-            title: `Unexpected file added`,
-          });
+          const lstat = await fs.lstat(join(options.dir, path));
+          if (lstat.isDirectory()) {
+            const dirContent = await fs.readdir(join(options.dir, path));
+            options.alert("Directory added:\n" + dirContent.join("\n"), {
+              file: path,
+              title: `Unexpected directory added`,
+            });
+          } else {
+            const newContent = await getNew(path);
+            options.alert("File added:\n" + newContent, {
+              file: path,
+              title: `Unexpected file added`,
+            });
+          }
           break;
         case "deleted":
           // Deleted


### PR DESCRIPTION
When adding a new directory, the whole directory is listed by git rather than the individual files. Check if the new thing is a directory and just list the files if it is.

- Add additional test for directory deletion. It just lists the files within the directory.
- Fix action name typo in the readme.